### PR TITLE
Call winLoad directly if document is loaded

### DIFF
--- a/svgxuse.js
+++ b/svgxuse.js
@@ -218,11 +218,18 @@
             uses = "";
             inProgressCount += 1;
             observeIfDone();
-        };
-        // The load event fires when all resources have finished loading, which allows detecting whether SVG use elements are empty.
-        window.addEventListener("load", function winLoad() {
+        }        
+        function winLoad() {
             window.removeEventListener("load", winLoad, false); // to prevent memory leaks
             tid = setTimeout(checkUseElems, 0);
-        }, false);
+        }
+
+        if (document.readyState !== "complete") {
+          // The load event fires when all resources have finished loading, which allows detecting whether SVG use elements are empty.
+          window.addEventListener("load", winLoad, false);
+        } else {
+          // No need to add a listener if the document is already loaded, initialize immediately.
+          winLoad();
+        }
     }
 }());


### PR DESCRIPTION
When using RequireJS the document may already have loaded everything when this script gets executed. This will cause the load event to never be triggered, bypassing the whole initialization. This PR adds a check for the document's ready state and calls the winLoad method directly if the document has already loaded.