### PR TITLE
fix: edge case where dynamically loaded element is off canvas

### DIFF
--- a/svgxuse.js
+++ b/svgxuse.js
@@ -189,6 +189,16 @@
                             }
                         }
                     }
+                    // fallback to forcing a repaint
+                    // logically when reaching this point, you still have a zero height/width element 
+                    // if none of the solutions were attempted
+                    if (!base.length || !(xhr !== true || xhr === undefined)) {
+                        if (isXlink) {
+                            uses[i].setAttributeNS(xlinkNS, "xlink:href", base + '#' + hash);
+                        } else {
+                            uses[i].setAttribute("href", base + '#' + hash);
+                        }
+                    }
                 } else {
                     if (!isHidden) {
                         if (cache[base] === undefined) {


### PR DESCRIPTION
Issues were happening on Chrome and IE. Firefox and Safari seemed fine.

### Before and after with Chrome on a local test environment

Before:
![image](https://user-images.githubusercontent.com/4655972/27117415-7c98a058-50a4-11e7-81b5-83629b306b6a.png)

After:
![image](https://user-images.githubusercontent.com/4655972/27117368-4d103698-50a4-11e7-87ed-c6d15d1cb86e.png)
