### PR TITLE
Do not use MutationObserver without the window. prefix

### DIFF
--- a/svgxuse.js
+++ b/svgxuse.js
@@ -24,7 +24,7 @@
             window.addEventListener("resize", debouncedCheck, false);
             window.addEventListener("orientationchange", debouncedCheck, false);
             if (window.MutationObserver) {
-                observer = new MutationObserver(debouncedCheck);
+                observer = new window.MutationObserver(debouncedCheck);
                 observer.observe(document.documentElement, {
                     childList: true,
                     subtree: true,


### PR DESCRIPTION
This PR makes a change to not use MutationObserver without the `window.` prefix, as Mocha only has `window.MutationObserver` defined.

Making this change allows me to run my unit tests on a project that's using this library.